### PR TITLE
Replaced placeholder string with actual db path

### DIFF
--- a/Data.fs
+++ b/Data.fs
@@ -6,7 +6,7 @@ open System.IO
 module Data = 
 
     [<Literal>]
-    let private connectionString = @"Data Source=" + __SOURCE_DIRECTORY__ + @"/Resources/task.sqlite;Version=3;" 
+    let connectionString = @"Data Source=" + __SOURCE_DIRECTORY__ + @"/Resources/task.sqlite;Version=3;" 
 
     type sql = SqlDataProvider<ConnectionString = connectionString,
                                DatabaseVendor = Common.DatabaseProviderTypes.SQLITE,

--- a/Data.fs
+++ b/Data.fs
@@ -5,7 +5,10 @@ open System.IO
 
 module Data = 
 
-    type sql = SqlDataProvider<ConnectionString = @"Data Source=Your Data Source Path;Version=3;",
+    [<Literal>]
+    let connectionString = @"Data Source=" + __SOURCE_DIRECTORY__ + @"/Resources/task.sqlite;Version=3;" 
+
+    type sql = SqlDataProvider<ConnectionString = connectionString,
                                DatabaseVendor = Common.DatabaseProviderTypes.SQLITE,
                                ResolutionPath = @"/Library/Frameworks/Mono.framework/Libraries/mono/4.5/",
                                UseOptionTypes = false>

--- a/Data.fs
+++ b/Data.fs
@@ -6,7 +6,7 @@ open System.IO
 module Data = 
 
     [<Literal>]
-    let connectionString = @"Data Source=" + __SOURCE_DIRECTORY__ + @"/Resources/task.sqlite;Version=3;" 
+    let private connectionString = @"Data Source=" + __SOURCE_DIRECTORY__ + @"/Resources/task.sqlite;Version=3;" 
 
     type sql = SqlDataProvider<ConnectionString = connectionString,
                                DatabaseVendor = Common.DatabaseProviderTypes.SQLITE,


### PR DESCRIPTION
Now ConnectionString uses the **SOURCE_DIRECTORY** path identifier to build the path of the actual db file included in the project instead of a generic placeholder.
