### PR TITLE
Change initialisation order to ensure that consistency exceptions are not thrown

### DIFF
--- a/AppDelegate.fs
+++ b/AppDelegate.fs
@@ -8,13 +8,14 @@ open MonoTouch.Foundation
 type AppDelegate () =
     inherit UIApplicationDelegate ()
 
-    let window = new UIWindow (UIScreen.MainScreen.Bounds)
+    override val Window = null with get,set
 
     // This method is invoked when the application is ready to run.
     override this.FinishedLaunching (app, options) =
         // If you have defined a root view controller, set it here:
-        window.RootViewController <- new UINavigationController(new TaskyViewController ())
-        window.MakeKeyAndVisible ()
+        this.Window <- new UIWindow (UIScreen.MainScreen.Bounds)
+        this.Window.RootViewController <- new UINavigationController(new TaskyViewController ())
+        this.Window.MakeKeyAndVisible ()
         true
 
 module Main =


### PR DESCRIPTION
This also fixes compatibility with iOS8
